### PR TITLE
Added option to return Enveloped data as bytes as well as strings. Th…

### DIFF
--- a/ctypescrypto/cms.py
+++ b/ctypescrypto/cms.py
@@ -104,6 +104,15 @@ class CMSBase(object):
             raise CMSError("writing CMS to DER")
         return str(bio)
 
+    def __bytes__(self):
+        """
+        Serialize in DER format. Return bytes
+        """
+        bio = Membio()
+        if not libcrypto.i2d_CMS_bio(bio.bio, self.ptr):
+            raise CMSError("writing CMS to DER")
+        return bytes(bio)
+
     def pem(self):
         """
         Serialize in PEM format
@@ -312,7 +321,11 @@ class EnvelopedData(CMSBase):
                                     bio.bio, flags)
         if res <= 0:
             raise CMSError("decrypting CMS")
-        return str(bio)
+
+        if flags & Flags.BINARY != 0: ## If we are expecting binary data
+            return bytes(bio) # we return bytes
+        else:
+            return str(bio) # else we return a string
 
 class EncryptedData(CMSBase):
     """


### PR DESCRIPTION
…is is useful in python 3 where strings are unicode. Current implementation is more pythonic and also relies on the flags to return appropriate data type from decryption of enveloped data.